### PR TITLE
Replace theme button with stylized sun/moon slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,16 @@
 
   <header class="app-header">
     <h1 id="title">Drum 🥁 Kit</h1>
-    <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch to light mode">Light Mode</button>
+    <div class="theme-toggle" role="presentation">
+      <span class="theme-toggle__icon theme-toggle__icon--sun" aria-hidden="true">☀️</span>
+      <label class="theme-toggle__control">
+        <input id="theme-toggle" type="checkbox" role="switch" aria-label="Switch to light mode">
+        <span class="theme-toggle__track" aria-hidden="true">
+          <span class="theme-toggle__thumb"></span>
+        </span>
+      </label>
+      <span class="theme-toggle__icon theme-toggle__icon--moon" aria-hidden="true">🌙</span>
+    </div>
   </header>
   <div class="set">
     <button class="w drum">w</button>

--- a/index.js
+++ b/index.js
@@ -17,19 +17,18 @@ document.addEventListener("keydown", function (event) {
 
 })
 
-var themeToggleButton = document.getElementById("theme-toggle")
+var themeToggleInput = document.getElementById("theme-toggle")
 var THEME_STORAGE_KEY = "drumkit-theme"
 var Theme = {
     LIGHT: "light",
     DARK: "dark"
 }
 
-if (themeToggleButton) {
+if (themeToggleInput) {
     applyTheme(getInitialTheme())
 
-    themeToggleButton.addEventListener("click", function () {
-        var isLightThemeActive = document.body.classList.contains("light-theme")
-        applyTheme(isLightThemeActive ? Theme.DARK : Theme.LIGHT)
+    themeToggleInput.addEventListener("change", function (event) {
+        applyTheme(event.target.checked ? Theme.LIGHT : Theme.DARK)
     })
 }
 
@@ -50,9 +49,9 @@ function applyTheme(theme) {
     var nextTheme = isLightTheme ? Theme.DARK : Theme.LIGHT
 
     document.body.classList.toggle("light-theme", isLightTheme)
-    themeToggleButton.textContent = nextTheme === Theme.LIGHT ? "Light Mode" : "Dark Mode"
-    themeToggleButton.setAttribute("aria-label", "Switch to " + nextTheme + " mode")
-    themeToggleButton.setAttribute("aria-pressed", String(isLightTheme))
+    themeToggleInput.checked = isLightTheme
+    themeToggleInput.setAttribute("aria-label", "Switch to " + nextTheme + " mode")
+    themeToggleInput.setAttribute("aria-checked", String(isLightTheme))
     localStorage.setItem(THEME_STORAGE_KEY, theme)
 }
 

--- a/styles.css
+++ b/styles.css
@@ -7,9 +7,13 @@
   --button-text: #DA0463;
   --button-shadow: #DBEDF3;
   --footer-text-color: #DBEDF3;
-  --toggle-border: #DBEDF3;
-  --toggle-bg: rgba(219, 237, 243, 0.12);
-  --toggle-text: #DBEDF3;
+  --toggle-border: rgba(219, 237, 243, 0.45);
+  --toggle-bg: rgba(40, 49, 73, 0.55);
+  --toggle-track: linear-gradient(135deg, rgba(218, 4, 99, 0.7), rgba(64, 75, 105, 0.85));
+  --toggle-thumb: #DBEDF3;
+  --toggle-glow: rgba(218, 4, 99, 0.4);
+  --toggle-icon-inactive: rgba(219, 237, 243, 0.55);
+  --toggle-icon-active: #DBEDF3;
 }
 
 body {
@@ -30,9 +34,13 @@ body.light-theme {
   --button-text: #c2185b;
   --button-shadow: rgba(30, 64, 175, 0.35);
   --footer-text-color: #1f2933;
-  --toggle-border: #94a3b8;
-  --toggle-bg: rgba(148, 163, 184, 0.15);
-  --toggle-text: #1f2933;
+  --toggle-border: rgba(148, 163, 184, 0.5);
+  --toggle-bg: rgba(255, 255, 255, 0.65);
+  --toggle-track: linear-gradient(135deg, rgba(148, 163, 184, 0.35), rgba(236, 72, 153, 0.45));
+  --toggle-thumb: #ffffff;
+  --toggle-glow: rgba(236, 72, 153, 0.2);
+  --toggle-icon-inactive: rgba(15, 23, 42, 0.35);
+  --toggle-icon-active: #c2185b;
 }
 
 .app-header {
@@ -52,31 +60,121 @@ h1 {
 }
 
 .theme-toggle {
-  border: 2px solid var(--toggle-border);
-  background-color: var(--toggle-bg);
-  color: var(--toggle-text);
-  padding: 0.5rem 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 1.1rem;
+  padding: 0.75rem 1.25rem;
   border-radius: 999px;
-  font-size: 1rem;
-  font-family: "Arvo", cursive;
-  cursor: pointer;
-  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, transform 0.2s ease;
+  border: 2px solid var(--toggle-border);
+  background: var(--toggle-bg);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.45);
+  transition: border-color 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
 }
 
-.theme-toggle:hover,
-.theme-toggle:focus-visible {
-  background-color: var(--button-bg);
-  color: var(--button-text);
+.theme-toggle:hover {
   border-color: var(--accent-color);
-  outline: none;
+  box-shadow: 0 24px 55px rgba(218, 4, 99, 0.35);
 }
 
-.theme-toggle:focus-visible {
-  box-shadow: 0 0 0 3px rgba(218, 4, 99, 0.35);
+.theme-toggle:focus-within {
+  box-shadow: 0 0 0 3px rgba(218, 4, 99, 0.35), 0 24px 55px rgba(218, 4, 99, 0.3);
 }
 
-.theme-toggle:active {
-  transform: translateY(1px);
+body.light-theme .theme-toggle {
+  box-shadow: 0 18px 40px rgba(148, 163, 184, 0.35);
+}
+
+body.light-theme .theme-toggle:hover {
+  box-shadow: 0 24px 55px rgba(236, 72, 153, 0.25);
+}
+
+body.light-theme .theme-toggle:focus-within {
+  box-shadow: 0 0 0 3px rgba(194, 24, 91, 0.35), 0 24px 55px rgba(236, 72, 153, 0.25);
+}
+
+.theme-toggle__icon {
+  font-size: 1.5rem;
+  color: var(--toggle-icon-inactive);
+  transition: color 0.3s ease, transform 0.3s ease, text-shadow 0.3s ease;
+}
+
+body.light-theme .theme-toggle__icon--sun,
+body:not(.light-theme) .theme-toggle__icon--moon {
+  color: var(--toggle-icon-active);
+  transform: scale(1.12);
+  text-shadow: 0 0 12px var(--toggle-glow);
+}
+
+.theme-toggle__control {
+  position: relative;
+  width: 66px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.theme-toggle__control input {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.theme-toggle__track {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: var(--toggle-track);
+  box-shadow: inset 0 2px 6px rgba(15, 23, 42, 0.45);
+  transition: background 0.4s ease, box-shadow 0.4s ease;
+}
+
+body.light-theme .theme-toggle__track {
+  box-shadow: inset 0 2px 6px rgba(15, 23, 42, 0.18);
+}
+
+.theme-toggle__control input:hover + .theme-toggle__track {
+  box-shadow: inset 0 2px 8px rgba(15, 23, 42, 0.45), 0 0 12px rgba(218, 4, 99, 0.2);
+}
+
+body.light-theme .theme-toggle__control input:hover + .theme-toggle__track {
+  box-shadow: inset 0 2px 8px rgba(15, 23, 42, 0.2), 0 0 12px rgba(236, 72, 153, 0.2);
+}
+
+.theme-toggle__thumb {
+  position: absolute;
+  top: 3px;
+  left: 4px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--toggle-thumb);
+  box-shadow: 0 10px 20px var(--toggle-glow);
+  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1), background 0.3s ease, box-shadow 0.35s ease;
+}
+
+.theme-toggle__control input:checked + .theme-toggle__track .theme-toggle__thumb {
+  transform: translateX(32px);
+}
+
+.theme-toggle__control input:focus-visible + .theme-toggle__track {
+  outline: 3px solid var(--accent-color);
+  outline-offset: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .theme-toggle,
+  .theme-toggle__icon,
+  .theme-toggle__track,
+  .theme-toggle__thumb {
+    transition: none;
+  }
 }
 
 footer {


### PR DESCRIPTION
## Summary
- replace the text theme toggle button with a slider switch framed by sun and moon icons
- restyle the toggle with gradients, glow effects, and focus states that adapt to each theme
- update the theme script to sync the new switch input with stored preferences and accessibility attributes

## Testing
- not run (static site; no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cbf9b9d31c832593e105d6e47c77be